### PR TITLE
Improve dev launch for LAN previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ A comprehensive **React/TypeScript frontend** + **Python FastAPI backend** platf
 
 **🆓 100% Free Data Sources** - No paid APIs, no rate limits, no account sign-ups required!
 
+## 🚀 Local preview (desktop + mobile)
+
+1. **Install once**: `npm run setup` (installs Node + Python dependencies)
+2. **Start everything**: `npm run start:dev`
+3. **Preview on any device**: open `http://<your-lan-ip>:3000` on your PC or phone (Node API on port 3001, Python API on 8000)
+
+All services bind to `0.0.0.0` and allow LAN origins by default, so mobile devices on the same network can reach the APIs without extra configuration.
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![Node.js 18+](https://img.shields.io/badge/node.js-18+-green.svg)](https://nodejs.org/)

--- a/backend/src/config/environment.ts
+++ b/backend/src/config/environment.ts
@@ -19,7 +19,7 @@ const envSchema = z.object({
   WS_PORT: z.string().transform(Number).default(3002),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
   JWT_SECRET: z.string().min(32),
-  CORS_ORIGIN: z.string().default('http://localhost:5173'),
+  CORS_ORIGIN: z.string().default('*'),
 
   // External APIs
   OPENBB_API_KEY: z.string().optional(),
@@ -68,6 +68,19 @@ const parseEnv = () => {
 
 const env = parseEnv();
 
+const parseCorsOrigins = (value: string): string[] | '*' => {
+  if (!value || value.trim() === '*') return '*';
+
+  const origins = value
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(Boolean);
+
+  return origins.length > 0 ? origins : '*';
+};
+
+const corsOrigin = parseCorsOrigins(env.CORS_ORIGIN);
+
 export const config = {
   // Database connections
   database: {
@@ -86,7 +99,7 @@ export const config = {
   wsPort: env.WS_PORT,
   nodeEnv: env.NODE_ENV,
   jwtSecret: env.JWT_SECRET,
-  corsOrigin: env.CORS_ORIGIN,
+  corsOrigin,
 
   // External APIs
   externalApis: {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -55,9 +55,11 @@ async function startServer() {
     const server = createServer(app);
 
     // Setup Socket.IO
+    const allowedOrigins = config.corsOrigin === '*' ? true : config.corsOrigin;
+
     const io = new SocketServer(server, {
       cors: {
-        origin: config.corsOrigin,
+        origin: allowedOrigins,
         methods: ['GET', 'POST']
       }
     });
@@ -65,8 +67,8 @@ async function startServer() {
     // Middleware
     app.use(helmet());
     app.use(cors({
-      origin: config.corsOrigin,
-      credentials: true
+      origin: allowedOrigins,
+      credentials: true,
     }));
     app.use(express.json({ limit: '10mb' }));
     app.use(express.urlencoded({ extended: true }));

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -129,20 +129,43 @@ EOF
 start_services() {
     echo "🚀 Starting services..."
 
-    # Start backend in background
-    echo "🔧 Starting backend platform..."
-    poetry run uvicorn bt_platform.core.app:app --reload --port 8000 &
-    BACKEND_PID=$!
+    # Start Node backend (primary API)
+    echo "🔧 Starting Node backend (real-time API)..."
+    export API_PORT=${API_PORT:-3001}
+    export CORS_ORIGIN=${CORS_ORIGIN:-"*"}
+    export JWT_SECRET=${JWT_SECRET:-"dev-secret-key-change-me-please-32-chars"}
+
+    cd backend
+    npm run dev > ../.dev-node.log 2>&1 &
+    NODE_BACKEND_PID=$!
+    cd ..
+
+    sleep 5
+
+    # Check if Node backend started successfully
+    if curl -s http://localhost:${API_PORT}/health > /dev/null; then
+        echo "✅ Node backend running at http://localhost:${API_PORT}"
+    else
+        echo "❌ Node backend failed to start (see .dev-node.log for details)"
+        kill $NODE_BACKEND_PID 2>/dev/null || true
+        exit 1
+    fi
+
+    # Start Python backend in background
+    echo "🐍 Starting Python backend (evidence graph API)..."
+    poetry run uvicorn bt_platform.core.app:app --reload --host 0.0.0.0 --port 8000 > .dev-python.log 2>&1 &
+    PY_BACKEND_PID=$!
 
     sleep 3
 
-    # Check if backend started successfully
+    # Check if Python backend started successfully
     if curl -s http://localhost:8000/health > /dev/null; then
-        echo "✅ Backend platform running at http://localhost:8000"
+        echo "✅ Python backend running at http://localhost:8000"
         echo "📖 API documentation at http://localhost:8000/docs"
     else
-        echo "❌ Backend failed to start"
-        kill $BACKEND_PID 2>/dev/null || true
+        echo "❌ Python backend failed to start (see .dev-python.log for details)"
+        kill $NODE_BACKEND_PID 2>/dev/null || true
+        kill $PY_BACKEND_PID 2>/dev/null || true
         exit 1
     fi
 
@@ -159,7 +182,8 @@ start_services() {
     # Cleanup function
     cleanup() {
         echo "🔄 Shutting down services..."
-        kill $BACKEND_PID 2>/dev/null || true
+        kill $NODE_BACKEND_PID 2>/dev/null || true
+        kill $PY_BACKEND_PID 2>/dev/null || true
         kill $FRONTEND_PID 2>/dev/null || true
         exit 0
     }
@@ -170,8 +194,10 @@ start_services() {
     echo ""
     echo "🎉 Biotech Terminal Platform is running!"
     echo ""
-    echo "📊 Backend API: http://localhost:8000"
-    echo "📖 API Docs: http://localhost:8000/docs"
+    echo "📊 Node API: http://localhost:${API_PORT}"
+    echo "📖 Node health: http://localhost:${API_PORT}/health"
+    echo "📊 Python API: http://localhost:8000"
+    echo "📖 Python docs: http://localhost:8000/docs"
     echo "🖥️ Terminal App: http://localhost:3000"
     echo ""
     echo "Press Ctrl+C to stop all services"

--- a/terminal/src/config/api.ts
+++ b/terminal/src/config/api.ts
@@ -8,13 +8,33 @@
  * - Contains all biotech intelligence APIs
  */
 
-// Get API base URL from environment or use defaults
+const DEFAULT_NODE_PORT = 3001;
+const DEFAULT_PYTHON_PORT = 8000;
+
+// Auto-detect host for mobile/preview scenarios where localhost won't resolve
+const resolveDefaultBaseUrl = (port: number) => {
+  if (typeof window === 'undefined') {
+    return `http://localhost:${port}`;
+  }
+
+  const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
+  const hostname = window.location.hostname || 'localhost';
+
+  // If running on a LAN IP (e.g., 192.168.x.x) reuse that host so mobile devices can reach the API
+  if (hostname !== 'localhost' && hostname !== '127.0.0.1') {
+    return `${protocol}//${hostname}:${port}`;
+  }
+
+  return `${protocol}//localhost:${port}`;
+};
+
+// Get API base URL from environment or use runtime-resolved defaults
 export const API_CONFIG = {
   // Node.js Express backend (real-time biotech data)
-  BASE_URL: import.meta.env.VITE_API_URL || 'http://localhost:3001',
+  BASE_URL: import.meta.env.VITE_API_URL || resolveDefaultBaseUrl(DEFAULT_NODE_PORT),
   VERSION: '/api',
   // Python FastAPI backend (evidence graph, core APIs)
-  PYTHON_BASE_URL: import.meta.env.VITE_PYTHON_API_URL || 'http://localhost:8000',
+  PYTHON_BASE_URL: import.meta.env.VITE_PYTHON_API_URL || resolveDefaultBaseUrl(DEFAULT_PYTHON_PORT),
   PYTHON_VERSION: '/api/v1',
 };
 

--- a/terminal/vite.config.ts
+++ b/terminal/vite.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const nodeApiTarget = env.VITE_API_URL || 'http://localhost:3001';
+  const pythonApiTarget = env.VITE_PYTHON_API_URL || 'http://localhost:8000';
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
+    },
+    server: {
+      host: '0.0.0.0',
+      port: 3000,
+      strictPort: true,
+      proxy: {
+        '/api': {
+          target: nodeApiTarget,
+          changeOrigin: true,
+        },
+        '/api/v1': {
+          target: pythonApiTarget,
+          changeOrigin: true,
+        },
+      },
+    },
+    preview: {
+      host: '0.0.0.0',
+      port: 4173,
+      proxy: {
+        '/api': {
+          target: nodeApiTarget,
+          changeOrigin: true,
+        },
+        '/api/v1': {
+          target: pythonApiTarget,
+          changeOrigin: true,
+        },
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- add a terminal Vite config that binds to 0.0.0.0 on port 3000 with backend proxies for LAN/mobile previews
- update the dev launcher to start both Node and Python APIs with sensible defaults and logs while binding backends to 0.0.0.0
- relax backend CORS defaults and document the one-command local preview flow for desktop and mobile

## Testing
- npm --prefix terminal run build *(fails: Vite cannot resolve `@biotech-terminal/frontend-components/terminal` during the terminal build)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69480a53b818832ca32c8f5f4d5c12b8)